### PR TITLE
Declare the Azure table series here instead of in stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "taskcluster-client": "0.22.6",
     "taskcluster-lib-stats": "^0.8.7"
   },
+  "peerDependencies": {
+    "taskcluster-lib-stats": "~0.8"
+  },
   "devDependencies": {
     "babel-compile": "0.0.3",
     "mocha": "2.0.1",

--- a/src/entity.js
+++ b/src/entity.js
@@ -10,7 +10,7 @@ var azureTable      = require('azure-table-node');
 var azure           = require('fast-azure-storage');
 var taskcluster     = require('taskcluster-client');
 var https           = require('https');
-var series          = require('taskcluster-lib-stats/lib/series');
+var series          = require('./series');
 var crypto          = require('crypto');
 
 // ** Coding Style **

--- a/src/series.js
+++ b/src/series.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var stats = require('taskcluster-lib-stats');
+var Series = stats.Series;
+
+/** Statistics from Azure table operations */
+exports.AzureTableOperations = new Series({
+  name: 'AzureTableOperations',
+  columns: {
+    component: stats.types.String,
+    process: stats.types.String,
+    duration: stats.types.Number,
+    table: stats.types.String,
+    method: stats.types.String,
+    error: stats.types.String
+  }
+});


### PR DESCRIPTION
We can generalize later as needed, but for now I'd like to focus on having taskcluster-base split out and this gets us that.  Please verify that I've set the peerDependency as you'd like it to be.