### PR TITLE
make errors with a .name, too

### DIFF
--- a/src/inmemory.js
+++ b/src/inmemory.js
@@ -57,6 +57,7 @@ var makeError = function(statusCode, code) {
   var err = new Error(code);
   err.statusCode = statusCode;
   err.code = code;
+  err.name = code + "Error";
   return err;
 };
 


### PR DESCRIPTION
tc-secrets uses `err.name` rather than `err.code`, and thus its tests are failing with inMemory.