### PR TITLE
Fixed write congestion bug, for multiple writers reaching consensus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-entities",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description": "azure-entities",
   "license": "MPL-2.0",

--- a/src/entity.js
+++ b/src/entity.js
@@ -991,20 +991,23 @@ Entity.prototype.reload = function() {
  */
 Entity.prototype.modify = function(modifier) {
   var self = this;
-
-  // Create a clone of this._properties, so we can compare properties and
-  // decide what to upload, as well as we can restore state if operations fail
-  var properties    = {};
-  _.forIn(this.__mapping, function(type, property) {
-    properties[property] = type.clone(self._properties[property]);
-  });
-  var eTag          = this._etag;
-  var version       = this._version;
+  var properties;
+  var eTag;
+  var version;
 
   // Attempt to modify this object
   var attemptsLeft = MAX_MODIFY_ATTEMPTS;
   var modifiedEntityAttempts = [];
   var attemptModify = function() {
+    // Create a clone of this._properties, so we can compare properties and
+    // decide what to upload, as well as we can restore state if operations fail
+    properties    = {};
+    _.forIn(self.__mapping, function(type, property) {
+      properties[property] = type.clone(self._properties[property]);
+    });
+    eTag          = self._etag;
+    version       = self._version;
+
     // Invoke modifier
     return Promise.resolve(modifier.call(
       self._properties,
@@ -1067,7 +1070,7 @@ Entity.prototype.modify = function(modifier) {
       });
     }).catch(function(err) {
       var modifiedEntity = self._properties;
-      
+
       // Restore internal state
       self._etag        = eTag;
       self._properties  = properties;
@@ -1372,4 +1375,3 @@ Entity.prototype.inspect = function(depth) {
 
 // Export Entity
 module.exports = Entity;
-

--- a/test/modify_test.js
+++ b/test/modify_test.js
@@ -13,7 +13,8 @@ var Item = subject.configure({
   properties: {
     id:             subject.types.String,
     name:           subject.types.String,
-    count:          subject.types.Number
+    count:          subject.types.Number,
+    time:           subject.types.Date,
   }
 });
 
@@ -30,7 +31,8 @@ function(context, options) {
     return Item.create({
       id:     id,
       name:   'my-test-item',
-      count:  1
+      count:  1,
+      time:   new Date(),
     }).then(function(item) {
       assert(item instanceof Item);
       assert(item.id === id);
@@ -64,7 +66,8 @@ function(context, options) {
     return Item.create({
       id:     id,
       name:   'my-test-item',
-      count:  1
+      count:  1,
+      time:   new Date(),
     }).then(function(item) {
       return item.modify(function() {
         throw err;
@@ -82,7 +85,8 @@ function(context, options) {
     return Item.create({
       id:     id,
       name:   'my-test-item',
-      count:  1
+      count:  1,
+      time:   new Date(),
     }).then(function(item) {
       deletedItem = item;
       return Item.remove({id: id, name: 'my-test-item'});
@@ -103,7 +107,8 @@ function(context, options) {
     return Item.create({
       id:     id,
       name:   'my-test-item',
-      count:  1
+      count:  1,
+      time:   new Date(),
     }).then(function(item) {
       assert(item instanceof Item);
       assert(item.id === id);
@@ -131,7 +136,8 @@ function(context, options) {
     return Item.create({
       id:     id,
       name:   'my-test-item',
-      count:  1
+      count:  1,
+      time:   new Date(),
     }).then(function(itemA) {
       return Item.load({
         id:     id,
@@ -163,7 +169,8 @@ function(context, options) {
     return Item.create({
       id:     id,
       name:   'my-test-item',
-      count:  1
+      count:  1,
+      time:   new Date(),
     }).then(function() {
       var promisedItems = [];
       for(var i = 0; i < 5; i++) {
@@ -196,4 +203,3 @@ function(context, options) {
     });
   });
 });
-


### PR DESCRIPTION
Please take a good look at this... I think I got it right and that there in fact was a bug...

I suspect the bug only caused unnecessary writes... Because it was calling `modifier` with `self` as argument, so the modified had the correct data available... even if it was reloaded...
But the result of the modifier `self` was compared to `properties` which wasn't updated if the entity was reloaded... This caused unnecessary writes as `isChanged` became true on cases where it shouldn't have been..


Also now using etag in tests to verify that this all works... 