### PR TITLE
Check that a migration doesn't return a falsy value (e.g. doesn't return an object!)

### DIFF
--- a/src/entity.js
+++ b/src/entity.js
@@ -489,7 +489,11 @@ Entity.configure = function(options) {
              "entity.Version is greater than configured version!");
       // Migrate, if necessary
       if (entity.Version < options.version) {
-        return options.migrate.call(this, deserialize.call(this, entity));
+        let migrated = options.migrate.call(this, deserialize.call(this, entity));
+        if (!migrated) {
+          throw new Error('migration must return value');
+        }
+        return migrated;
       }
       // Deserialize properties, if not migrated
       var cryptoKey  = this.__cryptoKey;


### PR DESCRIPTION
This caused a weird error for me hacking on the queue, but I think we should catch
this more generally and make it a check in the azure-entities library