### PR TITLE
yarn doesn't support 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- '0.12'
 - '4'
 - '6'
 - '7'


### PR DESCRIPTION
https://travis-ci.org/taskcluster/azure-entities/jobs/215108955b

> Node.js version v0.12.18 does not meet requirement for yarn. Please use Node.js 4 or later.
