### PR TITLE
Fix inMemory time comparisons

### DIFF
--- a/src/entitytypes.js
+++ b/src/entitytypes.js
@@ -358,8 +358,7 @@ DateType.prototype.filterCondition = function(op) {
 };
 
 DateType.prototype.compare = function(entity, op) {
-  return op.compare(new Date(entity[this.property]), op.operand);
-  throw new Error("Not implemented");
+  return op.compare(new Date(entity[this.property]).getTime(), op.operand.getTime());
 };
 
 

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -206,6 +206,17 @@ helper.contextualSuites("Entity (query)", [
     });
   });
 
+  test("Filter by time == Date(1)", function() {
+    var sum = 0;
+    return Item.query({
+      id:       id,
+      time:     new Date(1)
+    }).then(function(data) {
+      assert(data.entries.length === 1);
+      assert(data.entries[0].name == 'item2');
+    });
+  });
+
   test("Filter by time < Date(1)", function() {
     var sum = 0;
     return Item.query({


### PR DESCRIPTION
In trying to move the queue to use inMemory, I ran across this difference between azure and inMemory. Before the patch to `entitytpes.js`, this passed the azure test but not the inMemory one.