### PR TITLE
Do not allow credentials to be undefined even with inMemory

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,12 +193,14 @@ as follows:
 ```
 
 To use an in-memory, testing-oriented table, use the special accountName
-`inMemory`.  Credentials are not required.
+`inMemory`.  Credentials are not required. The field `credentials` must
+be specified, but can be null.
 
 ```js
 {
-  account:  "inMemory",
-  table:    "AzureTableName"
+  account:     "inMemory",
+  table:       "AzureTableName"
+  credentials: null,
 }
 ```
 

--- a/src/entity.js
+++ b/src/entity.js
@@ -578,8 +578,9 @@ Entity.configure = function(options) {
  * To use an in-memory, testing-oriented table, use the special accountName
  * `inMemory`.  Credentials are not required.
  * {
- *   account:  "inMemory,
- *   table:    "AzureTableName"
+ *   account:     "inMemory,
+ *   table:       "AzureTableName"
+ *   credentials: null,
  * }
  *
  * This implementation is largely true to Azure, but is intended only for
@@ -599,11 +600,14 @@ Entity.configure = function(options) {
  */
 Entity.setup = function(options) {
   // Validate options
-  assert(options,                             "options must be given");
-  assert(options.table,                       "options.table must be given");
-  assert(typeof(options.table) === 'string',  "options.table isn't a string");
-  assert(options.credentials || options.account == "inMemory",
-      "credentials are required unless using in-memory tables");
+  assert(options,                             'options must be given');
+  assert(options.table,                       'options.table must be given');
+  assert(typeof(options.table) === 'string',  'options.table isn\'t a string');
+  if (options.account === 'inMemory') {
+    assert(options.hasOwnProperty('credentials'), 'credentials should be specified even with inMemory, but can be null');
+  } else {
+    assert(options.credentials, 'credentials are required unless using in-memory tables');
+  }
   if (options.drain || options.component || options.process) {
     console.log('taskcluster-lib-stats is now deprecated!\n' +
                 'Use the `monitor` option rather than `drain`.\n' +

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -1,0 +1,52 @@
+var subject         = require('../lib/entity');
+var assert          = require('assert');
+
+suite('Config', function() {
+
+  let Item = subject.configure({
+    version:          1,
+    partitionKey:     subject.keys.StringKey('id'),
+    rowKey:           subject.keys.AscendingIntegerKey('rev'),
+    properties: {
+      id:             subject.types.SlugId,
+      rev:            subject.types.PositiveInteger,
+    }
+  });
+
+  test('inMemory with credentials', function() {
+    Item.setup({
+      account:   'inMemory',
+      table:    'items',
+      credentials: {clientId: 'foo', accountToken: 'bar'},
+    });
+  });
+
+  test('inMemory with no credentials', function() {
+    try {
+      Item.setup({
+        account:   'inMemory',
+        table:    'items',
+      });
+      assert(false, 'Should have thrown an error!');
+    } catch (e) {
+      assert(e.name === 'AssertionError');
+      assert(e.message === 'credentials should be specified even with inMemory, but can be null');
+    }
+  });
+
+  test('inMemory with null credentials', function() {
+    Item.setup({
+      account:   'inMemory',
+      table:    'items',
+      credentials: null,
+    });
+  });
+
+  test('inMemory with undefined credentials', function() {
+    Item.setup({
+      account:   'inMemory',
+      table:    'items',
+      credentials: undefined,
+    });
+  });
+});

--- a/test/create_load_test.js
+++ b/test/create_load_test.js
@@ -57,11 +57,13 @@ helper.contextualSuites("Entity (create/load)", [
       return {
         Item: ItemV1.setup({
           account:  "inMemory",
-          table:    'items'
+          table:    'items',
+          credentials: null,
         }),
         Item2: ItemV2.setup({
           account:  "inMemory",
-          table:    'items'
+          table:    'items',
+          credentials: null,
         }),
       };
     },

--- a/test/datatypes_test.js
+++ b/test/datatypes_test.js
@@ -172,7 +172,8 @@ helper.contextualSuites("Entity (create/load/modify DataTypes)", [
       context: "In-Memory",
       options: {
         account:   "inMemory",
-        table:    "items"
+        table:    "items",
+        credentials: null,
       }
     }
   ], function(context, options) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -33,7 +33,8 @@ exports.makeContexts = function(Item, setupOptions) {
         return {
           Item: Item.setup(_.defaults({}, setupOptions, {
             account: "inMemory",
-            table:   'items'
+            table:   'items',
+            credentials: null,
           }))
         };
       }

--- a/test/jsontype_test.js
+++ b/test/jsontype_test.js
@@ -46,7 +46,8 @@ helper.contextualSuites("Entity", [
       context: "In-Memory",
       options: {
         account:   "inMemory",
-        table:    "items"
+        table:    "items",
+        credentials: null,
       }
     }
   ], function(ctx, config) {

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -18,6 +18,7 @@ helper.contextualSuites("Entity (query)", [
     options: {
       account: "inMemory",
       table:   "items",
+      credentials: null,
     }
   },
 ], function(context, options) {

--- a/test/schematype_test.js
+++ b/test/schematype_test.js
@@ -43,7 +43,8 @@ helper.contextualSuites("Entity", [
       context: "In-Memory",
       options: {
         account:   "inMemory",
-        table:    "items"
+        table:    "items",
+        credentials: null,
       }
     }
   ], function(ctx, config) {

--- a/test/signentities_test.js
+++ b/test/signentities_test.js
@@ -18,6 +18,7 @@ helper.contextualSuites("Entity (signEntities)", [
     options: {
       account: "inMemory",
       table:   "items",
+      credentials: null,
     }
   },
 ], function(context, options) {

--- a/test/table_ops_test.js
+++ b/test/table_ops_test.js
@@ -35,7 +35,8 @@ helper.contextualSuites("Entity (modify)", [
       return {
         Item: Item.setup({
           account:  "inMemory",
-          table:    'items'
+          table:    'items',
+          credentials: null,
         })
       };
     }


### PR DESCRIPTION
I believe this would've helped prevent me from breaking the queue in production earlier today.

https://public.etherpad-mozilla.org/p/taskcluster-retrospective-inmemory-queue has more of my thoughts on what happened. It is WIP so far.

Also a couple of " -> ' changes in there.