### PR TITLE
Extend class to return an an array of strings

### DIFF
--- a/src/entitytypes.js
+++ b/src/entitytypes.js
@@ -906,11 +906,33 @@ var slugIdToBuffer = function(slug) {
   return new Buffer(base64, 'base64');
 };
 
+// Convert buffer to slugId where `entryIndex` is the slugId entry index to retrieve
+var bufferToSlugId = function (bufferView, entryIndex) {
+  return bufferView.toString('base64', entryIndex * SLUGID_SIZE, SLUGID_SIZE * (entryIndex + 1))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/==/g, '');
+};
+
 /** Array of slugids packed into a buffer for space and speed */
 var SlugIdArray = function() {
   this.buffer = new Buffer(SLUGID_SIZE * 32);
   this.length = 0;
   this.avail  = 32;
+};
+
+/** Retrieve all the entries added to the buffer in their original format i.e., before being turned into base64 slugIds */
+SlugIdArray.prototype.toArray = function() {
+  const buffer = this.getBufferView();
+  let result = [];
+
+  for (let i = 0; i < this.length; i++) {
+    const slug = bufferToSlugId(buffer, i);
+
+    result.push(slug);
+  }
+
+  return result;
 };
 
 /** Added slugid to end of the array */

--- a/test/slugidarray_test.js
+++ b/test/slugidarray_test.js
@@ -31,6 +31,39 @@ function(context, options) {
     arr.push(id);
   });
 
+  test("SlugIdArray.toArray", function() {
+    const slugArray = subject.types.SlugIdArray.create();
+    const slug1 = slugid.v4();
+    const slug2 = slugid.v4();
+
+    slugArray.push(slug1);
+    slugArray.push(slug2);
+
+    const arr = slugArray.toArray();
+
+    assert(slug1 === arr[0], `Expected ${slug1}`);
+    assert(slug2 === arr[1], `Expected ${slug2}`);
+  });
+
+  test("SlugIdArray.toArray (with 1k ids)", function() {
+    const slugArray = subject.types.SlugIdArray.create();
+    const N = 1000;
+    let slugids = [];
+
+    for (let i = 0; i < N; i++) {
+      const id = slugid.v4();
+
+      slugArray.push(id);
+      slugids.push(id)
+    }
+
+    const result = slugArray.toArray();
+
+    for (let i = 0; i < N; i++) {
+      assert(slugids[i] === result[i], `Expected ${slugids[i]}`);
+    }
+  });
+
   test("SlugIdArray.push (with 1k ids)", function() {
     var arr = subject.types.SlugIdArray.create();
     for(var i = 0; i < 1000; i++) {


### PR DESCRIPTION
I am trying to create an API to retrieve the most recent 20 tasksIds of a worker. The tasks Ids will be stored on azure using `SlugIdArray`. The latter manipulates data using a buffer and there is no way (as far as i know) to retrieve the entries added and put them in their original format. The front-end is not the right place to transform a buffer encoded base64 to an array of string.

I added a `toArray` method and a helper function `bufferToSlugId` so that when a call is made to retrieve information from data stored in `SlugIdArray`, I am able to give back to the user an array of strings. I could of did all of that logic in taskcluster-queue but figured it would better sit here.