### PR TITLE
Removed Buffertool dependency from azure-entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "ajv": "^5.3.0",
-    "buffertools": "^2.1.3",
     "debug": "^3.1.0",
     "fast-azure-storage": "^2.3.0",
     "json-stable-stringify": "^1.0.0",

--- a/src/entitytypes.js
+++ b/src/entitytypes.js
@@ -968,13 +968,13 @@ SlugIdArray.prototype.realloc = function() {
 /** Get indexOf of a slugid, -1 if it is not in the array */
 SlugIdArray.prototype.indexOf = function(slug) {
   var slug  = slugIdToBuffer(slug);
-  var index = Buffer.indexOf(this.buffer, slug);
+  var index = Buffer.indexof(this.buffer, slug);
 
   while (index !== -1 && index < this.length * SLUGID_SIZE) {
     if (index % SLUGID_SIZE === 0) {
       return index / SLUGID_SIZE;
     }
-    index = Buffer.indexOf(this.buffer, slug, index + 1);
+    index = Buffer.indexof(this.buffer, slug, index + 1);
   }
   return -1;
 };

--- a/src/entitytypes.js
+++ b/src/entitytypes.js
@@ -968,13 +968,13 @@ SlugIdArray.prototype.realloc = function() {
 /** Get indexOf of a slugid, -1 if it is not in the array */
 SlugIdArray.prototype.indexOf = function(slug) {
   var slug  = slugIdToBuffer(slug);
-  var index = this.buffer.indexOf( slug);
+  var index = this.buffer.indexOf(slug);
 
   while (index !== -1 && index < this.length * SLUGID_SIZE) {
     if (index % SLUGID_SIZE === 0) {
       return index / SLUGID_SIZE;
     }
-    index = this.buffer.indexOf( slug, index + 1);
+    index = this.buffer.indexOf(slug, index + 1);
   }
   return -1;
 };

--- a/src/entitytypes.js
+++ b/src/entitytypes.js
@@ -968,13 +968,13 @@ SlugIdArray.prototype.realloc = function() {
 /** Get indexOf of a slugid, -1 if it is not in the array */
 SlugIdArray.prototype.indexOf = function(slug) {
   var slug  = slugIdToBuffer(slug);
-  var index = Buffer.indexof(this.buffer, slug);
+  var index = this.buffer.indexOf( slug);
 
   while (index !== -1 && index < this.length * SLUGID_SIZE) {
     if (index % SLUGID_SIZE === 0) {
       return index / SLUGID_SIZE;
     }
-    index = Buffer.indexof(this.buffer, slug, index + 1);
+    index = this.buffer.indexOf( slug, index + 1);
   }
   return -1;
 };

--- a/src/entitytypes.js
+++ b/src/entitytypes.js
@@ -5,7 +5,6 @@ var _               = require('lodash');
 var debug           = require('debug')('entity:types');
 var slugid          = require('slugid');
 var stringify       = require('json-stable-stringify');
-var buffertools     = require('buffertools');
 var crypto          = require('crypto');
 var azure           = require('fast-azure-storage');
 var Ajv             = require('ajv');
@@ -558,7 +557,7 @@ BlobType.prototype.equal = function(value1, value2) {
   if (value1.length !== value2.length) {
     return false;
   }
-  return buffertools.compare(value1, value2) === 0;
+  return Buffer.compare(value1, value2) === 0;
 };
 
 BlobType.prototype.clone = function(value) {
@@ -762,7 +761,7 @@ EncryptedBlobType.prototype.equal = function(value1, value2) {
   if (value1.length !== value2.length) {
     return false;
   }
-  return buffertools.compare(value1, value2) === 0;
+  return Buffer.compare(value1, value2) === 0;
 };
 
 EncryptedBlobType.prototype.clone = function(value) {
@@ -969,13 +968,13 @@ SlugIdArray.prototype.realloc = function() {
 /** Get indexOf of a slugid, -1 if it is not in the array */
 SlugIdArray.prototype.indexOf = function(slug) {
   var slug  = slugIdToBuffer(slug);
-  var index = buffertools.indexOf(this.buffer, slug);
+  var index = Buffer.indexOf(this.buffer, slug);
 
   while (index !== -1 && index < this.length * SLUGID_SIZE) {
     if (index % SLUGID_SIZE === 0) {
       return index / SLUGID_SIZE;
     }
-    index = buffertools.indexOf(this.buffer, slug, index + 1);
+    index = Buffer.indexOf(this.buffer, slug, index + 1);
   }
   return -1;
 };
@@ -1079,7 +1078,7 @@ SlugIdArray.prototype.clone = function() {
 /** Compare slugid arrays */
 SlugIdArray.prototype.equals = function(other) {
   assert(other instanceof SlugIdArray, 'Expected a SlugIdArray');
-  return buffertools.compare(
+  return Buffer.compare(
     this.getBufferView(),
     other.getBufferView()
   ) === 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -299,11 +299,6 @@ browser-stdout@1.3.0:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
   integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
 
-buffertools@^2.1.3:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/buffertools/-/buffertools-2.1.6.tgz#30c19b085636b88df692aeefeea0ff156780e916"
-  integrity sha1-MMGbCFY2uI32kq7v7qD/FWeA6RY=
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"


### PR DESCRIPTION
**Buffertool** was used in **entitytypes.js** file . The file was already using the Buffer module of node js

Two methods of buffertool package were used `compare()` and `indexof()` in the file

Replaced them with equivalent js code (used Buffer module of node js)

Ran the test locally , kindly cross check for convenience

Thank You