### PR TITLE
Bug 1596098 - reject with a specific error for too-large properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The following types are encrypted, and require additional arguments to the
 Note that all entity types have a maximum stored size of 256k.  Do not store
 values of unbounded size in a single row.
 
+Note that the arbitrary-sized property types, such as String and Blob, can result in an error with `err.code === 'PropertyTooLarge'` if the property is too large.
+
 #### Keys
 
 The `partitionKey` and `rowKey` options are used to describe how the Azure
@@ -328,6 +330,8 @@ await entity.modify(function(entity) {
   entity.property = "new value";
 });
 ```
+
+Note that the arbitrary-sized property types, such as String and Blob, can result in an error with `err.code === 'PropertyTooLarge'` on creation or modification if the property is too large.
 
 The `remove` method will remove a row.  This can be called either as a class
 method (in which case the row is not loaded) or as an instance method.  Both

--- a/src/entity.js
+++ b/src/entity.js
@@ -788,7 +788,7 @@ Entity.removeTable = function() {
  * Create an entity on azure table with property and mapping.
  * Returns a promise for an instance of `this` (typically an Entity subclass)
  */
-Entity.create = function(properties, overwriteIfExists) {
+Entity.create = async function(properties, overwriteIfExists) {
   var Class       = this;
   var ClassProps  = Class.prototype;
   assert(properties, 'Properties is required');

--- a/test/blobtype_test.js
+++ b/test/blobtype_test.js
@@ -94,7 +94,7 @@ helper.contextualSuites('Entity (BlobType)', helper.makeContexts(Item),
     });
 
     test('large blob (256k)', function() {
-      var id  = slugid.v4();7;
+      var id  = slugid.v4();
       var buf = crypto.pseudoRandomBytes(256 * 1024);
       return Item.create({
         id:     id,
@@ -108,5 +108,15 @@ helper.contextualSuites('Entity (BlobType)', helper.makeContexts(Item),
           assert(compareBuffers(itemA.data, itemB.data));
         });
       });
+    });
+
+    test('too-large blob (512k)', function() {
+      var id  = slugid.v4();
+      var buf = crypto.pseudoRandomBytes(512 * 1024);
+      return assert.rejects(() => Item.create({
+        id:     id,
+        name:   'my-test-item',
+        data:   buf,
+      }), err => err.code === 'PropertyTooLarge');
     });
   });


### PR DESCRIPTION
The additional "async" in the Entity.create method is so that the method
returns a rejected Promise in this condition, instead of synchronously
throwing an error.